### PR TITLE
Update to laravel 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "illuminate/translation": "5.4",
-    "illuminate/database": "5.*",
-    "illuminate/cache": "5.*",
+    "php": ">=5.6.0",
+    "illuminate/translation": "5.4.*",
+    "illuminate/database": "5.4.*",
+    "illuminate/cache": "5.4.*",
     "stichoza/google-translate-php": "~3.1"
   },
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "illuminate/translation": "5.4.*",
     "illuminate/database": "5.4.*",
     "illuminate/cache": "5.4.*",
-    "stichoza/google-translate-php": "~3.1"
+    "stichoza/google-translate-php": "~3.1",
+    "illuminate/contracts": "5.4.*"
   },
 
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/translation": "5.*",
+    "illuminate/translation": "5.4",
     "illuminate/database": "5.*",
     "illuminate/cache": "5.*",
     "stichoza/google-translate-php": "~3.1"

--- a/config/translation-db.php
+++ b/config/translation-db.php
@@ -34,4 +34,12 @@ return [
      * happening.
      */
     'minimal' => false,
+
+    /**
+     * Use locales from files as a fallback option. Be aware that
+     * locales are loaded as groups. When just one locale of a group
+     * exists in the database, a file will never be used.
+     * To use some files, keep these groups fully out of your database.
+     */
+    'file_fallback' => false,
 ];

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ adding your keys to the translations file, automatic translation with **Google T
 Require this package with composer:
 
 ```
-composer require hpolthof/laravel-translation-db
+composer require hpolthof/laravel-translations-db
 ```
 > Like to live on the edge?
 > Use: ```composer require 'hpolthof/laravel-translations-db:*@dev'```

--- a/src/Console/Commands/DumpCommand.php
+++ b/src/Console/Commands/DumpCommand.php
@@ -186,7 +186,12 @@ EOF;
 	{
 		$new_content = array();
 		foreach ($content as $key => $value) {
-			$this->assignArrayByPath($new_content, $key, $value);
+			// Quick fix, see: https://github.com/hpolthof/laravel-translations-db/issues/13
+			//$this->assignArrayByPath($new_content, $key, $value);
+			if($value){
+    				array_set($new_content, $key, $value);
+			}
+			ksort($new_content);
 		}
 		$content = $new_content;
 		return $content;

--- a/src/Console/Commands/FetchCommand.php
+++ b/src/Console/Commands/FetchCommand.php
@@ -260,7 +260,18 @@ class FetchCommand extends Command {
         foreach ($keys as $name => $value) {
             list($inserted, $updated) = $this->storeTranslation($locale, $group, $name, $value, $inserted, $updated);
         }
+
+        $this->flushCache($locale, $group);
+
         $this->info("Fetched {$locale}/{$group}.php [New: {$inserted}, Updated: {$updated}]");
     }
 
+    /**
+     * @param $locale
+     * @param $group
+     */
+    protected function flushCache($locale, $group)
+    {
+        \Cache::forget('__translations.'.$locale.'.'.$group);
+    }
 }

--- a/src/Controllers/TranslationsController.php
+++ b/src/Controllers/TranslationsController.php
@@ -24,7 +24,7 @@ class TranslationsController extends Controller {
             ->select('group')
             ->distinct()
             ->orderBy('group')
-            ->lists('group');
+            ->pluck('group');
     }
 
     public function getLocales() {
@@ -32,7 +32,7 @@ class TranslationsController extends Controller {
             ->select('locale')
             ->distinct()
             ->orderBy('locale')
-            ->lists('locale');
+            ->pluck('locale');
     }
 
     public function postItems(Request $request) {
@@ -49,7 +49,7 @@ class TranslationsController extends Controller {
             ->where('locale', strtolower($request->get('translate')))
             ->where('group', $request->get('group'))
             ->orderBy('name')
-            ->lists('value', 'name');
+            ->pluck('value', 'name');
 
         foreach($base as &$item) {
             $translate = null;

--- a/src/Controllers/TranslationsController.php
+++ b/src/Controllers/TranslationsController.php
@@ -1,5 +1,6 @@
 <?php namespace Hpolthof\Translation\Controllers;
 
+use Hpolthof\Translation\ServiceProvider;
 use Hpolthof\Translation\TranslationException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -20,19 +21,21 @@ class TranslationsController extends Controller {
     }
 
     public function getGroups() {
-        return \DB::table('translations')
+        $query = \DB::table('translations')
             ->select('group')
             ->distinct()
-            ->orderBy('group')
-            ->pluck('group');
+            ->orderBy('group');
+
+        return ServiceProvider::pluckOrLists($query, 'group');
     }
 
     public function getLocales() {
-        return \DB::table('translations')
+        $query = \DB::table('translations')
             ->select('locale')
             ->distinct()
-            ->orderBy('locale')
-            ->pluck('locale');
+            ->orderBy('locale');
+
+        return ServiceProvider::pluckOrLists($query, 'locale');
     }
 
     public function postItems(Request $request) {
@@ -48,8 +51,8 @@ class TranslationsController extends Controller {
             ->select('name', 'value')
             ->where('locale', strtolower($request->get('translate')))
             ->where('group', $request->get('group'))
-            ->orderBy('name')
-            ->pluck('value', 'name');
+            ->orderBy('name');
+        $new = ServiceProvider::pluckOrLists($new, 'value', 'name');
 
         foreach($base as &$item) {
             $translate = null;

--- a/src/DatabaseLoader.php
+++ b/src/DatabaseLoader.php
@@ -25,7 +25,7 @@ class DatabaseLoader implements LoaderInterface {
         return \DB::table('translations')
             ->where('locale', $locale)
             ->where('group', $group)
-            ->lists('value', 'name');
+            ->pluck('value', 'name');
     }
 
     /**

--- a/src/DatabaseLoader.php
+++ b/src/DatabaseLoader.php
@@ -22,10 +22,11 @@ class DatabaseLoader implements LoaderInterface {
      */
     public function load($locale, $group, $namespace = null)
     {
-        return \DB::table('translations')
+        $query = \DB::table('translations')
             ->where('locale', $locale)
-            ->where('group', $group)
-            ->pluck('value', 'name');
+            ->where('group', $group);
+
+        return ServiceProvider::pluckOrLists($query, 'value', 'name');
     }
 
     /**

--- a/src/DatabaseLoader.php
+++ b/src/DatabaseLoader.php
@@ -102,6 +102,8 @@ class DatabaseLoader implements LoaderInterface {
         }
     }
 
+    public function namespaces() {}
+
     protected function replaceNullValues($results, $group, $locale) {
         $default = $this->_app['config']->get('translation-db.default_translation');
         $fallback = $this->_app['config']->get('app.fallback_locale');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Hpolthof\Translation;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Translation\FileLoader;
 
 class ServiceProvider extends \Illuminate\Translation\TranslationServiceProvider {
@@ -135,4 +136,22 @@ class ServiceProvider extends \Illuminate\Translation\TranslationServiceProvider
 		return array('translator', 'translation.loader', 'translation.database');
 	}
 
+	/**
+	 * Alternative pluck to stay backwards compatible with Laravel 5.1 LTS.
+	 *
+	 * @param Builder $query
+	 * @param $column
+	 * @param null $key
+	 * @return array|mixed
+	 */
+	public static function pluckOrLists(Builder $query, $column, $key = null)
+	{
+		if(\Illuminate\Foundation\Application::VERSION < '5.2') {
+			$result = $query->lists($column, $key);
+		} else {
+			$result = $query->pluck($column, $key);
+		}
+
+		return $result;
+	}
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -36,7 +36,7 @@ class Translator extends \Illuminate\Translation\Translator implements Translato
 		// Here we will get the locale that should be used for the language line. If one
 		// was not passed, we will use the default locales which was given to us when
 		// the translator was instantiated. Then, we can load the lines and return.
-		foreach ($this->parseLocale($locale) as $locale)
+		foreach ($this->localeArray($locale) as $locale)
 		{
 			$this->load($namespace, $group, $locale);
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Translation\LoaderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;;
 
-class Translator extends \Illuminate\Translation\Translator implements TranslatorInterface {
+class Translator extends \Illuminate\Translation\Translator implements TranslatorContract {
 
 	protected $app = null;
 


### PR DESCRIPTION
Compatibility with laravel 5.4

- Merge hpolthof/master
- Switch to `Illuminate\Contracts\Translation\Translator`  instead of `Symfony\Component\Translation\TranslatorInterface` (due to compatibility issues between Symfony and Illuminate translations components) 
 