### PR TITLE
Update to Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "illuminate/translation": "5.4.*",
-    "illuminate/database": "5.4.*",
-    "illuminate/cache": "5.4.*",
+    "illuminate/translation": "5.5.*",
+    "illuminate/database": "5.5.*",
+    "illuminate/cache": "5.5.*",
     "stichoza/google-translate-php": "~3.1",
-    "illuminate/contracts": "5.4.*"
+    "illuminate/contracts": "5.5.*"
   },
 
   "autoload": {

--- a/src/Console/Commands/DumpCommand.php
+++ b/src/Console/Commands/DumpCommand.php
@@ -28,7 +28,7 @@ class DumpCommand extends Command {
 	 *
 	 * @return mixed
 	 */
-	public function fire()
+	public function handle()
 	{
 		$query = \DB::table('translations')->select('locale', 'group', 'name', 'value');
 		$this->addOptionToQuery($query, 'locale');

--- a/src/Console/Commands/FetchCommand.php
+++ b/src/Console/Commands/FetchCommand.php
@@ -37,7 +37,7 @@ class FetchCommand extends Command {
      *
      * @return mixed
      */
-    public function fire() {
+    public function handle() {
         if(!$this->validate()) return false;
 
         $locales = $this->usableLocales();

--- a/src/Console/Commands/RemoveCommand.php
+++ b/src/Console/Commands/RemoveCommand.php
@@ -39,7 +39,7 @@ class RemoveCommand extends Command {
      *
      * @return mixed
      */
-    public function fire() {
+    public function handle() {
         $this->setArguments();
         $this->removeTranslations();
     }

--- a/src/DatabaseLoader.php
+++ b/src/DatabaseLoader.php
@@ -1,9 +1,9 @@
 <?php namespace Hpolthof\Translation;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Translation\LoaderInterface;
+use Illuminate\Contracts\Translation\Loader;
 
-class DatabaseLoader implements LoaderInterface {
+class DatabaseLoader implements Loader {
 
     protected $_app = null, $domain_id;
 
@@ -110,6 +110,7 @@ class DatabaseLoader implements LoaderInterface {
     }
 
     public function namespaces() {}
+    public function addJsonPath($path) {}
 
     /**
      * Replace null values with their default value

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -1,14 +1,14 @@
 <?php namespace Hpolthof\Translation;;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Translation\LoaderInterface;
-use Illuminate\Contracts\Translation\Translator as TranslatorContract;;
+use Illuminate\Contracts\Translation\Loader;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class Translator extends \Illuminate\Translation\Translator implements TranslatorContract {
 
 	protected $app = null;
 
-	public function __construct(LoaderInterface $database, LoaderInterface $loader, $locale, Application $app)
+	public function __construct(Loader $database, Loader $loader, $locale, Application $app)
 	{
 		$this->database = $database;
 		$this->app = $app;


### PR DESCRIPTION
The following changes is nessary for upgrading to Laravel 5.5
- Rename `Illuminate\Translation\LoaderInterface` to `Illuminate\Contracts\Translation\Loader`
  - Add new `addJsonPath` method
- rename commands `fire` method to `handle`

Tested by running `translation:fetch` task