### PR TITLE
Only search for translations that exists in domain_id null

### DIFF
--- a/src/Console/Commands/FetchCommand.php
+++ b/src/Console/Commands/FetchCommand.php
@@ -211,6 +211,7 @@ class FetchCommand extends Command {
      */
     protected function storeTranslation($locale, $group, $name, $value, $inserted, $updated) {
         $item = \DB::table('translations')
+            ->whereNull('domain_id')
             ->where('locale', $locale)
             ->where('group', $group)
             ->where('name', $name)->first();


### PR DESCRIPTION
Der eksisterede nogle tilfælde, hvor den default translation var forsvundet, men domænets translation eksisterede stadig. 

closes https://github.com/interFace-dk/clubsystem_ny/issues/1175